### PR TITLE
Dockerfile: add gst-vaapi to enable gstreamer to play AAC streams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex \
     gst-plugins-base \
     gst-plugins-good \
     gst-plugins-ugly \
+    gst-vaapi \
     libxml2 \
     python3 \
     python3-dev \


### PR DESCRIPTION
This adds the package gst-vaapi to the image, which is needed by gstreamer to play streams in AAC encoding.